### PR TITLE
Recursive bisection community detection

### DIFF
--- a/config/km1_direct_kway_sea17.ini
+++ b/config/km1_direct_kway_sea17.ini
@@ -17,6 +17,7 @@ p-large-net-removal=false
 # main -> preprocessing -> community detection
 p-use-louvain=true
 p-use-louvain-in-ip=true
+p-reuse-communities=false
 p-max-louvain-pass-iterations=100
 p-min-eps-improvement=0.0001
 p-louvain-edge-weight=hybrid

--- a/kahypar/application/command_line_options.h
+++ b/kahypar/application/command_line_options.h
@@ -202,7 +202,11 @@ void processCommandLineInput(Context& context, int argc, char* argv[]) {
     " - uniform\n"
     " - non_uniform\n"
     " - degree \n"
-    "(default: hybrid)");
+    "(default: hybrid)")
+    ("p-reuse-communities",
+    po::value<bool>(&context.preprocessing.louvain_community_detection.reuse_communities)->value_name("<bool>"),
+    "Reuse the community structure identified in the first bisection for all other bisections.\n"
+    "(default: false)");
 
   po::options_description coarsening_options("Coarsening Options", num_columns);
   coarsening_options.add_options()

--- a/kahypar/datastructure/hypergraph.h
+++ b/kahypar/datastructure/hypergraph.h
@@ -1699,6 +1699,9 @@ class GenericHypergraph {
   FRIEND_TEST(AHypergraph, ExtractedFromAPartitionedHypergraphHasInitializedPartitionInformation);
   FRIEND_TEST(AHypergraph, RemovesEmptyHyperedgesOnHypernodeIsolation);
   FRIEND_TEST(AHypergraph, RestoresRemovedEmptyHyperedgesOnRestoreOfIsolatedHypernodes);
+  FRIEND_TEST(APartitionedHypergraph, CanBeDecomposedIntoHypergraphs);
+  FRIEND_TEST(AHypergraph,
+              WithOnePartitionEqualsTheExtractedHypergraphExceptForPartitionRelatedInfos);
 
   /*!
    * Returns true if hypernode is a border-node.

--- a/kahypar/datastructure/hypergraph.h
+++ b/kahypar/datastructure/hypergraph.h
@@ -1700,6 +1700,7 @@ class GenericHypergraph {
   FRIEND_TEST(AHypergraph, RemovesEmptyHyperedgesOnHypernodeIsolation);
   FRIEND_TEST(AHypergraph, RestoresRemovedEmptyHyperedgesOnRestoreOfIsolatedHypernodes);
   FRIEND_TEST(APartitionedHypergraph, CanBeDecomposedIntoHypergraphs);
+  FRIEND_TEST(AHypergraph, WithContractedHypernodesCanBeReindexed);
   FRIEND_TEST(AHypergraph,
               WithOnePartitionEqualsTheExtractedHypergraphExceptForPartitionRelatedInfos);
 

--- a/kahypar/datastructure/hypergraph.h
+++ b/kahypar/datastructure/hypergraph.h
@@ -1654,6 +1654,10 @@ class GenericHypergraph {
     _communities = std::move(communities);
   }
 
+  void resetCommunities() {
+    std::fill(_communities.begin(), _communities.end(), 0);
+  }
+
 
   // ! Returns the sum of the weights of all hypernodes in a block
   HypernodeWeight partWeight(const PartitionID id) const {

--- a/kahypar/datastructure/hypergraph.h
+++ b/kahypar/datastructure/hypergraph.h
@@ -2125,7 +2125,6 @@ std::pair<std::unique_ptr<Hypergraph>,
 reindex(const Hypergraph& hypergraph) {
   using HypernodeID = typename Hypergraph::HypernodeID;
   using HyperedgeID = typename Hypergraph::HyperedgeID;
-  using PartitionID = typename Hypergraph::PartitionID;
 
   std::unordered_map<HypernodeID, HypernodeID> original_to_reindexed;
   std::vector<HypernodeID> reindexed_to_original;
@@ -2148,7 +2147,7 @@ reindex(const Hypergraph& hypergraph) {
     }
     ASSERT(std::none_of(reindexed_hypergraph->_communities.cbegin(),
                         reindexed_hypergraph->_communities.cend(),
-                        [](PartitionID i) {
+                        [](typename Hypergraph::PartitionID i) {
           return i == -1;
         }));
   }
@@ -2220,7 +2219,6 @@ extractPartAsUnpartitionedHypergraphForBisection(const Hypergraph& hypergraph,
                                                  const bool split_nets = false) {
   using HypernodeID = typename Hypergraph::HypernodeID;
   using HyperedgeID = typename Hypergraph::HyperedgeID;
-  using PartitionID = typename Hypergraph::PartitionID;
 
   std::unordered_map<HypernodeID, HypernodeID> hypergraph_to_subhypergraph;
   std::vector<HypernodeID> subhypergraph_to_hypergraph;
@@ -2247,7 +2245,7 @@ extractPartAsUnpartitionedHypergraphForBisection(const Hypergraph& hypergraph,
       }
       ASSERT(std::none_of(subhypergraph->_communities.cbegin(),
                           subhypergraph->_communities.cend(),
-                          [](PartitionID i) {
+                          [](typename Hypergraph::PartitionID i) {
             return i == -1;
           }));
     }

--- a/kahypar/io/sql_plottools_serializer.h
+++ b/kahypar/io/sql_plottools_serializer.h
@@ -82,6 +82,8 @@ static inline void serialize(const Context& context, const Hypergraph& hypergrap
       << " max_louvain_pass_iterations=" << context.preprocessing.louvain_community_detection.max_pass_iterations
       << " min_louvain_eps_improvement=" << context.preprocessing.louvain_community_detection.min_eps_improvement
       << " louvain_edge_weight=" << toString(context.preprocessing.louvain_community_detection.edge_weight)
+      << " reuse_community_structure=" << std::boolalpha
+      << context.preprocessing.louvain_community_detection.reuse_communities
       << " coarsening_algo=" << toString(context.coarsening.algorithm)
       << " coarsening_max_allowed_weight_multiplier=" << context.coarsening.max_allowed_weight_multiplier
       << " coarsening_contraction_limit_multiplier=" << context.coarsening.contraction_limit_multiplier

--- a/kahypar/partition/coarsening/heavy_edge_rater.h
+++ b/kahypar/partition/coarsening/heavy_edge_rater.h
@@ -78,20 +78,7 @@ class HeavyEdgeRater {
     _hg(hypergraph),
     _context(context),
     _tmp_ratings(_hg.initialNumNodes()),
-    _already_matched(_hg.initialNumNodes()) {
-    if (_context.preprocessing.enable_louvain_community_detection) {
-      const bool verbose_output = (_context.type == ContextType::main &&
-                                   _context.partition.verbose_output);
-      if (verbose_output) {
-        LOG << "Performing community detection:";
-      }
-      hypergraph.setCommunities(detectCommunities(_hg, _context));
-      if (verbose_output) {
-        LOG << "  # communities = " << context.stats.preprocessing("Communities");
-        LOG << "  modularity    = " << context.stats.preprocessing("Modularity");
-      }
-    }
-  }
+    _already_matched(_hg.initialNumNodes()) { }
 
   HeavyEdgeRater(const HeavyEdgeRater&) = delete;
   HeavyEdgeRater& operator= (const HeavyEdgeRater&) = delete;

--- a/kahypar/partition/context.h
+++ b/kahypar/partition/context.h
@@ -45,6 +45,7 @@ struct MinHashSparsifierParameters {
 
 struct LouvainCommunityDetection {
   bool enable_in_initial_partitioning = false;
+  bool reuse_communities = false;
   LouvainEdgeWeight edge_weight = LouvainEdgeWeight::hybrid;
   int max_pass_iterations = 100;
   long double min_eps_improvement = 0.0001;

--- a/kahypar/partition/context.h
+++ b/kahypar/partition/context.h
@@ -89,6 +89,8 @@ inline std::ostream& operator<< (std::ostream& str, const LouvainCommunityDetect
       << params.min_eps_improvement << std::endl;
   str << "  graph edge weight:                  "
       << toString(params.edge_weight) << std::endl;
+  str << "  reuse community structure:          " << std::boolalpha
+      << params.reuse_communities << std::endl;
   return str;
 }
 
@@ -111,7 +113,7 @@ inline std::ostream& operator<< (std::ostream& str, const PreprocessingParameter
   if (params.enable_louvain_community_detection) {
     str << "-------------------------------------------------------------------------------"
         << std::endl;
-    str << params.louvain_community_detection << std::endl;
+    str << params.louvain_community_detection;
   }
 
   return str;

--- a/kahypar/partition/initial_partition.h
+++ b/kahypar/partition/initial_partition.h
@@ -137,7 +137,7 @@ static inline Context createContext(const Hypergraph& hg,
       LOG << "Invalid IP technique";
       std::exit(-1);
   }
-  // We are now in initial partitioning mode, i.e. the next call to partitionInitially
+  // We are now in initial partitioning mode, i.e. the next call to partition
   // will actually trigger the computation of an initial partition of the hypergraph.
   // Computing an actual initial partition is always flat, since the graph has been coarsened
   // before in case of multilevel initial partitioning, or should not be coarsened in case

--- a/kahypar/partition/initial_partition.h
+++ b/kahypar/partition/initial_partition.h
@@ -155,7 +155,6 @@ static inline Context createContext(const Hypergraph& hg,
 static inline void partition(Hypergraph& hg, const Context& context) {
   auto extracted_init_hypergraph = ds::reindex(hg);
   std::vector<HypernodeID> mapping(std::move(extracted_init_hypergraph.second));
-
   double init_alpha = context.initial_partitioning.init_alpha;
   double best_imbalance = std::numeric_limits<double>::max();
   std::vector<PartitionID> best_imbalanced_partition(
@@ -163,6 +162,8 @@ static inline void partition(Hypergraph& hg, const Context& context) {
 
   do {
     extracted_init_hypergraph.first->resetPartitioning();
+    // we do not want to use the community structure used during coarsening in initial partitioning
+    extracted_init_hypergraph.first->resetCommunities();
     Context init_context = createContext(*extracted_init_hypergraph.first, context, init_alpha);
 
     if (context.initial_partitioning.verbose_output) {

--- a/kahypar/partition/partitioner.h
+++ b/kahypar/partition/partitioner.h
@@ -180,7 +180,7 @@ inline void Partitioner::setupContext(const Hypergraph& hypergraph, Context& con
 inline void Partitioner::preprocess(Hypergraph& hypergraph, const Context& context) {
   if (context.partition.verbose_output) {
     LOG << "\n********************************************************************************";
-    LOG << "*                               Preprocessing...                               *";
+    LOG << "*                          Top Level Preprocessing..                           *";
     LOG << "********************************************************************************";
   }
   const auto result = _single_node_he_remover.removeSingleNodeHyperedges(hypergraph);
@@ -202,17 +202,12 @@ inline void Partitioner::preprocess(Hypergraph& hypergraph, const Context& conte
         std::chrono::duration<double>(end - start).count();
     }
   }
-  if (context.preprocessing.enable_louvain_community_detection) {
-    const bool verbose_output = (context.type == ContextType::main &&
-                                 context.partition.verbose_output);
-    if (verbose_output) {
-      LOG << "Performing community detection:";
-    }
-    hypergraph.setCommunities(detectCommunities(hypergraph, context));
-    if (verbose_output) {
-      LOG << "  # communities = " << context.stats.preprocessing("Communities");
-      LOG << "  modularity    = " << context.stats.preprocessing("Modularity");
-    }
+
+  // In recursive bisection mode, we perform community detection before each
+  // bisection. Therefore the 'top-level' preprocessing is disabled in this case.
+  if (context.partition.mode != Mode::recursive_bisection &&
+      context.preprocessing.enable_louvain_community_detection) {
+    detectCommunities(hypergraph, context);
   }
 }
 

--- a/kahypar/partition/partitioner.h
+++ b/kahypar/partition/partitioner.h
@@ -202,6 +202,18 @@ inline void Partitioner::preprocess(Hypergraph& hypergraph, const Context& conte
         std::chrono::duration<double>(end - start).count();
     }
   }
+  if (context.preprocessing.enable_louvain_community_detection) {
+    const bool verbose_output = (context.type == ContextType::main &&
+                                 context.partition.verbose_output);
+    if (verbose_output) {
+      LOG << "Performing community detection:";
+    }
+    hypergraph.setCommunities(detectCommunities(hypergraph, context));
+    if (verbose_output) {
+      LOG << "  # communities = " << context.stats.preprocessing("Communities");
+      LOG << "  modularity    = " << context.stats.preprocessing("Modularity");
+    }
+  }
 }
 
 inline void Partitioner::preprocess(Hypergraph& hypergraph, Hypergraph& sparse_hypergraph,

--- a/kahypar/partition/preprocessing/louvain.h
+++ b/kahypar/partition/preprocessing/louvain.h
@@ -292,8 +292,8 @@ inline void detectCommunities(Hypergraph& hypergraph, const Context& context) {
   }
   hypergraph.setCommunities(internal::detectCommunities(hypergraph, context));
   if (verbose_output) {
-    LOG << "  # communities = " << context.stats.preprocessing("Communities");
-    LOG << "  modularity    = " << context.stats.preprocessing("Modularity");
+    LOG << "  # communities =" << context.stats.preprocessing("Communities");
+    LOG << "  modularity    =" << context.stats.preprocessing("Modularity");
   }
 }
 }  // namespace kahypar

--- a/kahypar/partition/preprocessing/louvain.h
+++ b/kahypar/partition/preprocessing/louvain.h
@@ -254,7 +254,7 @@ class Louvain {
   const Context& _context;
 };
 
-
+namespace internal {
 inline std::vector<ClusterID> detectCommunities(const Hypergraph& hypergraph,
                                                 const Context& context) {
   Louvain<Modularity> louvain(hypergraph, context);
@@ -276,8 +276,24 @@ inline std::vector<ClusterID> detectCommunities(const Hypergraph& hypergraph,
   }
   ASSERT(std::none_of(communities.cbegin(), communities.cend(),
                       [](ClusterID i) {
-      return i == -1;
-    }));
+        return i == -1;
+      }));
   return communities;
+}
+}  // namespace internal
+
+inline void detectCommunities(Hypergraph& hypergraph, const Context& context) {
+  const bool verbose_output = (context.type == ContextType::main &&
+                               context.partition.verbose_output) ||
+                              (context.type == ContextType::initial_partitioning &&
+                               context.initial_partitioning.verbose_output);
+  if (verbose_output) {
+    LOG << "Performing community detection:";
+  }
+  hypergraph.setCommunities(internal::detectCommunities(hypergraph, context));
+  if (verbose_output) {
+    LOG << "  # communities = " << context.stats.preprocessing("Communities");
+    LOG << "  modularity    = " << context.stats.preprocessing("Modularity");
+  }
 }
 }  // namespace kahypar

--- a/kahypar/partition/recursive_bisection.h
+++ b/kahypar/partition/recursive_bisection.h
@@ -197,6 +197,24 @@ static inline void partition(Hypergraph& input_hypergraph,
             LOG << R"(========================================)"
                    R"(========================================)";
           }
+          // TODO(schlag): This is probably the right point to handle recursive bisection mode
+          // as well
+          if (current_context.type == ContextType::initial_partitioning) {
+            if (current_context.preprocessing.enable_louvain_community_detection) {
+              const bool verbose_output = (current_context.type == ContextType::main &&
+                                           current_context.partition.verbose_output);
+              if (verbose_output) {
+                LOG << "Performing community detection:";
+              }
+              current_hypergraph.setCommunities(detectCommunities(current_hypergraph,
+                                                                  current_context));
+              if (verbose_output) {
+                LOG << "  # communities = " << current_context.stats.preprocessing("Communities");
+                LOG << "  modularity    = " << current_context.stats.preprocessing("Modularity");
+              }
+            }
+          }
+
           std::unique_ptr<ICoarsener> coarsener(
             CoarsenerFactory::getInstance().createObject(
               current_context.coarsening.algorithm,

--- a/kahypar/partition/recursive_bisection.h
+++ b/kahypar/partition/recursive_bisection.h
@@ -197,23 +197,20 @@ static inline void partition(Hypergraph& input_hypergraph,
             LOG << R"(========================================)"
                    R"(========================================)";
           }
-          // TODO(schlag): This is probably the right point to handle recursive bisection mode
-          // as well
-          if (current_context.type == ContextType::initial_partitioning) {
-            if (current_context.preprocessing.enable_louvain_community_detection) {
-              const bool verbose_output = (current_context.type == ContextType::main &&
-                                           current_context.partition.verbose_output);
-              if (verbose_output) {
-                LOG << "Performing community detection:";
-              }
-              current_hypergraph.setCommunities(detectCommunities(current_hypergraph,
-                                                                  current_context));
-              if (verbose_output) {
-                LOG << "  # communities = " << current_context.stats.preprocessing("Communities");
-                LOG << "  modularity    = " << current_context.stats.preprocessing("Modularity");
-              }
+
+          if (current_context.preprocessing.enable_louvain_community_detection) {
+            if (current_context.type == ContextType::main &&
+                current_context.partition.verbose_output) {
+              LOG << "******************************************"
+                     "**************************************";
+              LOG << "*                               Preprocessing..."
+                     "                               *";
+              LOG << "*********************************************"
+                     "***********************************";
             }
+            detectCommunities(current_hypergraph, current_context);
           }
+
 
           std::unique_ptr<ICoarsener> coarsener(
             CoarsenerFactory::getInstance().createObject(

--- a/kahypar/partition/recursive_bisection.h
+++ b/kahypar/partition/recursive_bisection.h
@@ -211,15 +211,23 @@ static inline void partition(Hypergraph& input_hypergraph,
                      "***********************************";
             }
 
-            // In recursive bisection mode, we want to be able to reuse the community
-            // structure computed as preprocessing before the first bisection for the subsequent
-            // bisections. This is made sure using the following implication:
-            // RB-Mode ==> first bisection OR always compute community structure
-            if (current_context.type != ContextType::main || bisection_counter == 1 ||
-                !current_context.preprocessing.louvain_community_detection.reuse_communities) {
+            // For both recursive bisection and direct k-way partitioning mode, we allow to reuse
+            // community structure information. Direct k-way partitioning uses recursive bisection
+            // as initial partitioning mode. Using the reuse_communities flag, we can therefore
+            // decide whether or not the community structure found before the first bisection
+            // (which corresponds to the community structure of the input hypergraph for recursive
+            // bisection based partitioning and to the community structure of the coarse hypergraph
+            // for direct k-way partitioning) should be reused in subsequent bisections. Note that
+            // the community structure computed in the top level preprocessing phase of direct k-way
+            // partitioning is not used here, because we clear the communities vector before calling
+            // the initial partitioner (see initial_partition.h).
+            const bool detect_communities =
+              !current_context.preprocessing.louvain_community_detection.reuse_communities ||
+              bisection_counter == 1;
+            if (detect_communities) {
               detectCommunities(current_hypergraph, current_context);
-            } else if (recursive_bisection_verbose) {
-              LOG << "Reusing community structure of first bisection";
+            } else if (verbose_output) {
+              LOG << "Reusing community structure computed in first bisection";
             }
           }
 

--- a/tests/datastructure/hypergraph_test.cc
+++ b/tests/datastructure/hypergraph_test.cc
@@ -662,6 +662,14 @@ TEST_F(AHypergraph, MaintainsItsTotalWeight) {
 }
 
 TEST_F(APartitionedHypergraph, CanBeDecomposedIntoHypergraphs) {
+  hypergraph._communities[0] = 0;
+  hypergraph._communities[1] = 2;
+  hypergraph._communities[2] = 4;
+  hypergraph._communities[3] = 6;
+  hypergraph._communities[4] = 8;
+  hypergraph._communities[5] = 10;
+  hypergraph._communities[6] = 12;
+
   auto extr_part0 = extractPartAsUnpartitionedHypergraphForBisection(hypergraph, 0);
   auto extr_part1 = extractPartAsUnpartitionedHypergraphForBisection(hypergraph, 1);
   Hypergraph& part0_hypergraph = *extr_part0.first;
@@ -681,6 +689,9 @@ TEST_F(APartitionedHypergraph, CanBeDecomposedIntoHypergraphs) {
 
   ASSERT_THAT(mapping_0, ContainerEq(std::vector<HypernodeID>{ 0, 1, 3, 4 }));
   ASSERT_THAT(mapping_1, ContainerEq(std::vector<HypernodeID>{ 2, 5, 6 }));
+
+  ASSERT_THAT(part0_hypergraph._communities, ContainerEq(std::vector<PartitionID>{ 0, 2, 6, 8 }));
+  ASSERT_THAT(part1_hypergraph._communities, ContainerEq(std::vector<PartitionID>{ 4, 10, 12 }));
 }
 
 TEST_F(AHypergraph, WithOnePartitionEqualsTheExtractedHypergraphExceptForPartitionRelatedInfos) {
@@ -691,6 +702,15 @@ TEST_F(AHypergraph, WithOnePartitionEqualsTheExtractedHypergraphExceptForPartiti
   hypergraph.setNodePart(4, 0);
   hypergraph.setNodePart(5, 0);
   hypergraph.setNodePart(6, 0);
+
+  hypergraph._communities[0] = 0;
+  hypergraph._communities[1] = 2;
+  hypergraph._communities[2] = 4;
+  hypergraph._communities[3] = 6;
+  hypergraph._communities[4] = 8;
+  hypergraph._communities[5] = 10;
+  hypergraph._communities[6] = 12;
+
   auto extr_part0 = extractPartAsUnpartitionedHypergraphForBisection(hypergraph, 0);
   ASSERT_THAT(verifyEquivalenceWithoutPartitionInfo(hypergraph, *extr_part0.first), Eq(true));
 }

--- a/tests/datastructure/hypergraph_test.cc
+++ b/tests/datastructure/hypergraph_test.cc
@@ -801,12 +801,22 @@ TEST_F(AHypergraph, WithContractedHypernodesCanBeReindexed) {
   hypergraph.contract(0, 2);
   hypergraph.removeEdge(1);
 
+  hypergraph._communities[0] = 0;
+  hypergraph._communities[1] = 2;
+  hypergraph._communities[2] = 4;
+  hypergraph._communities[3] = 6;
+  hypergraph._communities[4] = 8;
+  hypergraph._communities[5] = 10;
+  hypergraph._communities[6] = 12;
+
   auto reindexed = reindex(hypergraph);
 
   ASSERT_THAT(reindexed.first->initialNumNodes(), Eq(5));
   ASSERT_THAT(reindexed.first->currentNumEdges(), Eq(3));
   ASSERT_THAT(reindexed.second.size(), Eq(5));
   ASSERT_THAT(reindexed.second, ContainerEq(std::vector<HypernodeID>{ 0, 1, 3, 5, 6 }));
+  ASSERT_THAT(reindexed.first->_communities,
+              ContainerEq(std::vector<PartitionID>{ 0, 2, 6, 10, 12 }));
 }
 
 TEST_F(APartitionedHypergraph, CanBeResetToUnpartitionedState) {


### PR DESCRIPTION
Community detection using the Louvain method was introduced in the SEA'17 paper for direct k-way partitioning. Recursive bisection based partitioning supported community detection by running the Louvain method before each bisection. Since this is very expensive, we now provide a way to reuse the community structure computed before the first bisection in all subsequent bisections. However, for backwards compatibility, we do not enable this feature by default.
 
It can be enabled by using the ``--p-reuse-communities=1`` command line option.

If KaHyPar runs in recursive bisection mode, the community structure of the input hypergraph is used for all bisections. If KaHyPar runs in direct k-way mode, the recursive bisection based initial partitioner reuses the community structure of the coarsend hypergraph for all subsequent bisections.

Testcases are modified to ensure that community structure is retained when reindexing a hypergraph or extracting a subhypergraph.