### PR TITLE
Allow variable block sizes

### DIFF
--- a/kahypar/application/command_line_options.h
+++ b/kahypar/application/command_line_options.h
@@ -79,7 +79,13 @@ po::options_description createGeneralOptionsDescription(Context& context, const 
     "Hyperedges larger than cmaxnet are ignored during partitioning process.")
     ("vcycles",
     po::value<uint32_t>(&context.partition.global_search_iterations)->value_name("<uint32_t>"),
-    "# V-cycle iterations for direct k-way partitioning");
+    "# V-cycle iterations for direct k-way partitioning")
+        ("use-individual-blockweights",
+    po::value<bool>(&context.partition.use_individual_block_weights)->value_name("<bool>"),
+    "# Use individual block weights specified with --blockweights= option")
+      ("blockweights",
+       po::value<std::vector<HypernodeWeight>>(&context.partition.max_part_weights)->multitoken(),
+       "Individual target block weights");
   return options;
 }
 
@@ -565,6 +571,11 @@ void processCommandLineInput(Context& context, int argc, char* argv[]) {
     + ".seed"
     + std::to_string(context.partition.seed)
     + ".KaHyPar";
+
+  if (context.partition.use_individual_block_weights) {
+    context.partition.epsilon = 0;
+  }
+
 }
 
 

--- a/kahypar/partition/context.h
+++ b/kahypar/partition/context.h
@@ -303,11 +303,11 @@ struct PartitioningParameters {
   int seed = 0;
   uint32_t global_search_iterations = std::numeric_limits<uint32_t>::max();
   mutable uint32_t current_v_cycle = 0;
-  std::array<HypernodeWeight, 2> perfect_balance_part_weights { {
+  std::vector<HypernodeWeight> perfect_balance_part_weights { {
                                                                   std::numeric_limits<HypernodeWeight>::max(),
                                                                   std::numeric_limits<HypernodeWeight>::max()
                                                                 } };
-  std::array<HypernodeWeight, 2> max_part_weights { { std::numeric_limits<HypernodeWeight>::max(),
+  std::vector<HypernodeWeight> max_part_weights { { std::numeric_limits<HypernodeWeight>::max(),
                                                       std::numeric_limits<HypernodeWeight>::max() } };
   HypernodeWeight total_graph_weight = std::numeric_limits<HypernodeWeight>::max();
   HyperedgeID hyperedge_size_threshold = std::numeric_limits<HypernodeID>::max();
@@ -315,6 +315,7 @@ struct PartitioningParameters {
   bool verbose_output = false;
   bool quiet_mode = false;
   bool sp_process_output = false;
+  bool use_individual_block_weights = false;
 
   std::string graph_filename { };
   std::string graph_partition_filename { };
@@ -332,12 +333,21 @@ inline std::ostream& operator<< (std::ostream& str, const PartitioningParameters
   str << "  # V-cycles:                         " << params.global_search_iterations << std::endl;
   str << "  hyperedge size threshold:           " << params.hyperedge_size_threshold << std::endl;
   str << "  total hypergraph weight:            " << params.total_graph_weight << std::endl;
+  str << "  use individual block weights:       " << std::boolalpha
+      << params.use_individual_block_weights << std::endl;
+  if (params.use_individual_block_weights) {
+    for (PartitionID i = 0; i < params.k; ++i) {
+      str << "  L_max" << i << ":                             " << params.max_part_weights[i]
+          << std::endl;
+    }
+  } else {
   str << "  L_opt0:                             " << params.perfect_balance_part_weights[0]
       << std::endl;
   str << "  L_opt1:                             " << params.perfect_balance_part_weights[1]
       << std::endl;
   str << "  L_max0:                             " << params.max_part_weights[0] << std::endl;
   str << "  L_max1:                             " << params.max_part_weights[1] << std::endl;
+  }
   return str;
 }
 

--- a/kahypar/partition/context.h
+++ b/kahypar/partition/context.h
@@ -509,5 +509,31 @@ static inline void sanityCheck(Context& context) {
       // should never happen, because initial partitioning is either done via RB or directly
       break;
   }
+  if (context.partition.use_individual_block_weights &&
+      context.partition.max_part_weights[0] == std::numeric_limits<HypernodeWeight>::max()) {
+    LOG << "Individual block weights not specified. Please use --blockweights to specify the weight of each block";
+    std::exit(0);
+  }
+
+  if (!context.partition.use_individual_block_weights &&
+      context.partition.max_part_weights[0] != std::numeric_limits<HypernodeWeight>::max()) {
+    LOG << "Individual block weights specified, but --use-individual-blockweights=false.";
+    LOG << "Do you want to use the block weights you specified (Y/N)?";
+    char answer = 'N';
+    std::cin >> answer;
+    answer = std::toupper(answer);
+    if (answer == 'Y') {
+      context.partition.use_individual_block_weights = true;
+    } else {
+      LOG << "Individual block weights will be ignored. Partition with imbalance epsilon="
+          << context.partition.epsilon << " (Y/N)?";
+      answer = 'N';
+      std::cin >> answer;
+      answer = std::toupper(answer);
+      if (answer == 'N') {
+        std::exit(0);
+      }
+    }
+  }
 }
 }  // namespace kahypar

--- a/kahypar/partition/initial_partition.h
+++ b/kahypar/partition/initial_partition.h
@@ -57,12 +57,22 @@ static inline Context createContext(const Hypergraph& hg,
 
   context.initial_partitioning.perfect_balance_partition_weight.clear();
   context.initial_partitioning.upper_allowed_partition_weight.clear();
+
+  if (context.partition.use_individual_block_weights) {
+    for (int i = context.partition.rb_lower_k; i <= context.partition.rb_upper_k; ++i) {
+      context.initial_partitioning.perfect_balance_partition_weight.push_back(
+          context.partition.perfect_balance_part_weights[i]);
+    context.initial_partitioning.upper_allowed_partition_weight.push_back(
+      context.initial_partitioning.perfect_balance_partition_weight[i]);
+    }
+  } else {
   for (int i = 0; i < context.initial_partitioning.k; ++i) {
     context.initial_partitioning.perfect_balance_partition_weight.push_back(
       context.partition.perfect_balance_part_weights[i % 2]);
     context.initial_partitioning.upper_allowed_partition_weight.push_back(
       context.initial_partitioning.perfect_balance_partition_weight[i]
       * (1.0 + context.partition.epsilon));
+  }
   }
 
   // Coarsening-Parameters

--- a/kahypar/partition/initial_partitioning/initial_partitioner_base.h
+++ b/kahypar/partition/initial_partitioning/initial_partitioner_base.h
@@ -63,10 +63,16 @@ class InitialPartitionerBase {
   virtual ~InitialPartitionerBase() = default;
 
   void recalculateBalanceConstraints(const double epsilon) {
-    for (int i = 0; i < _context.initial_partitioning.k; ++i) {
-      _context.initial_partitioning.upper_allowed_partition_weight[i] =
-        _context.initial_partitioning.perfect_balance_partition_weight[i]
-        * (1.0 + epsilon);
+
+    if (!_context.partition.use_individual_block_weights){
+      for (int i = 0; i < _context.initial_partitioning.k; ++i) {
+        _context.initial_partitioning.upper_allowed_partition_weight[i] =
+            _context.initial_partitioning.perfect_balance_partition_weight[i]
+            * (1.0 + epsilon);
+      }
+    } else {
+      _context.initial_partitioning.upper_allowed_partition_weight =
+          _context.initial_partitioning.perfect_balance_partition_weight;
     }
     _context.partition.max_part_weights[0] =
       _context.initial_partitioning.upper_allowed_partition_weight[0];

--- a/kahypar/partition/metrics.h
+++ b/kahypar/partition/metrics.h
@@ -143,7 +143,8 @@ static inline double imbalance(const Hypergraph& hypergraph, const Context& cont
     // to direct k-way partitioning and each part has the same perfect_balance weight and Lmax
     const double balance_i =
       (hypergraph.partWeight(i) /
-       static_cast<double>(context.partition.perfect_balance_part_weights[1]));
+       static_cast<double>(context.partition.perfect_balance_part_weights[
+           context.partition.use_individual_block_weights? i : 1]));
     max_balance = std::max(max_balance, balance_i);
   }
 

--- a/kahypar/partition/partitioner.h
+++ b/kahypar/partition/partitioner.h
@@ -174,7 +174,13 @@ inline void Partitioner::setupContext(const Hypergraph& hypergraph, Context& con
     context.coarsening.max_allowed_weight_multiplier
     / context.coarsening.contraction_limit;
 
-  context.partition.perfect_balance_part_weights[0] = ceil(
+  context.coarsening.max_allowed_node_weight = ceil(context.coarsening.hypernode_weight_fraction
+                                                    * context.partition.total_graph_weight);
+
+  if (context.partition.use_individual_block_weights) {
+        context.partition.perfect_balance_part_weights = context.partition.max_part_weights;
+  } else {
+      context.partition.perfect_balance_part_weights[0] = ceil(
     context.partition.total_graph_weight
     / static_cast<double>(context.partition.k));
   context.partition.perfect_balance_part_weights[1] =
@@ -183,9 +189,7 @@ inline void Partitioner::setupContext(const Hypergraph& hypergraph, Context& con
   context.partition.max_part_weights[0] = (1 + context.partition.epsilon)
                                           * context.partition.perfect_balance_part_weights[0];
   context.partition.max_part_weights[1] = context.partition.max_part_weights[0];
-
-  context.coarsening.max_allowed_node_weight = ceil(context.coarsening.hypernode_weight_fraction
-                                                    * context.partition.total_graph_weight);
+  }
 }
 
 inline void Partitioner::sanitize(Hypergraph& hypergraph, const Context& context) {

--- a/tests/end_to_end/kahypar_test_fixtures.h
+++ b/tests/end_to_end/kahypar_test_fixtures.h
@@ -34,6 +34,8 @@ class KaHyParCA : public ::testing::Test {
     context.partition.mode = Mode::direct_kway;
     context.partition.objective = Objective::cut;
     context.partition.seed = 2;
+    context.partition.rb_lower_k = 0;
+    context.partition.rb_upper_k = 0;
     context.preprocessing.enable_community_detection = true;
     context.preprocessing.enable_min_hash_sparsifier = true;
     context.preprocessing.community_detection.enable_in_initial_partitioning = true;
@@ -76,6 +78,8 @@ class KaHyParK : public ::testing::Test {
     context.partition.mode = Mode::direct_kway;
     context.partition.objective = Objective::cut;
     context.partition.seed = 2;
+    context.partition.rb_lower_k = 0;
+    context.partition.rb_upper_k = 0;
     context.coarsening.algorithm = CoarseningAlgorithm::ml_style;
     context.coarsening.max_allowed_weight_multiplier = 1;
     context.coarsening.contraction_limit_multiplier = 160;
@@ -106,6 +110,8 @@ class KaHyParR : public ::testing::Test {
     context.partition.mode = Mode::recursive_bisection;
     context.partition.objective = Objective::cut;
     context.partition.seed = 2;
+    context.partition.rb_lower_k = 0;
+    context.partition.rb_upper_k = 0;
     context.coarsening.algorithm = CoarseningAlgorithm::heavy_lazy;
     context.coarsening.max_allowed_weight_multiplier = 3.25;
     context.coarsening.contraction_limit_multiplier = 160;


### PR DESCRIPTION
KaHyPar now supports individual target block weights via --use-individual-blockweights=1 --blockweights=<...>

This is one of the requirements for the bioinformatics practical at KIT: https://sco.h-its.org/exelixis/web/teaching/BioinformaticsModule.html