### PR TITLE
.lgtm.yml: remove GCC 6 override

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -3,20 +3,6 @@ queries:
   - exclude: codestyle/
 extraction:
   cpp:
-    prepare:    # Customizable step used by all languages.
-      packages:
-        - g++-6
-        - libboost-all-dev
-#    after_prepare:    # Customizable step used by all languages.
-#      - mkdir -p $LGTM_WORKSPACE/latest-gcc-symlinks
-#      - ln -s /usr/bin/g++-6 $LGTM_WORKSPACE/latest-gcc-symlinks/g++
-#      - ln -s /usr/bin/gcc-6 $LGTM_WORKSPACE/latest-gcc-symlinks/gcc
-#      - export PATH=$LGTM_WORKSPACE/latest-gcc-symlinks:$PATH
-#      - export GNU_MAKE=make
-#      - export GIT=true
-#    before_index:    # Customizable step used by all languages.
-#      - export BOOST_DIR=$LGTM_SRC/boost
-#      - export GTEST_DIR=$LGTM_SRC/googletest
     index:    # Customizable step used by all languages.
       build_command:
         - cd $LGTM_SRC


### PR DESCRIPTION
This override of the compiler to always use GCC 6 seems to have been copied from [an example in the LGTM documentation](https://help.semmle.com/lgtm-enterprise/archive/1.22/user/help/lgtm.yml-configuration-file.html#example-lgtm.yml-file) that was not intended to be used literally. We'll update that example before our next release.

I've tested that the build still works at https://lgtm.com/logs/b19fb92c02c82286b9ce305766f4de543f87c542/lang:cpp.