### PR TITLE
Add conversion and evaluation tools for Mondriaan partitioning

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -50,6 +50,12 @@ set_property(TARGET DegreePinDistribution PROPERTY CXX_STANDARD_REQUIRED ON)
 add_executable(ComputeNeighborHoodSizes compute_neighborhood_sizes.cc)
 set_property(TARGET ComputeNeighborHoodSizes PROPERTY CXX_STANDARD 14)
 set_property(TARGET ComputeNeighborHoodSizes PROPERTY CXX_STANDARD_REQUIRED ON)
+add_executable(HgrToMondriaanMtx hgr_to_mondriaan_mtx_converter.cc)
+set_property(TARGET HgrToMondriaanMtx PROPERTY CXX_STANDARD 14)
+set_property(TARGET HgrToMondriaanMtx PROPERTY CXX_STANDARD_REQUIRED ON)
+add_executable(EvaluateMondriaanPartition evaluate_mondriaan_partition.cc)
+set_property(TARGET EvaluateMondriaanPartition PROPERTY CXX_STANDARD 14)
+set_property(TARGET EvaluateMondriaanPartition PROPERTY CXX_STANDARD_REQUIRED ON)
 
 
 
@@ -60,6 +66,7 @@ add_gmock_test(mtx_to_hgr_converter_test mtx_to_hgr_converter_test.cc mtx_to_hgr
 add_gmock_test(cnf_to_hgr_converter_test cnf_to_hgr_converter_test.cc)
 add_gmock_test(hgr_to_edge_list_conversion_test hgr_to_edge_list_conversion_test.cc)
 add_gmock_test(repeats_to_hgr_conversion_test repeats_to_hgr_conversion_test.cc)
+add_gmock_test(hgr_to_mtx_test hgr_to_mtx_conversion_test.cc)
 
 
 #set_source_files_properties(hmetis_lib_test.cc PROPERTIES COMPILE_FLAGS -m32)

--- a/tools/evaluate_mondriaan_partition.cc
+++ b/tools/evaluate_mondriaan_partition.cc
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * This file is part of KaHyPar.
+ *
+ * Copyright (C) 2019 Sebastian Schlag <sebastian.schlag@kit.edu>
+ *
+ * KaHyPar is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KaHyPar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with KaHyPar.  If not, see <http://www.gnu.org/licenses/>.
+ *
+******************************************************************************/
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "kahypar/definitions.h"
+#include "kahypar/io/hypergraph_io.h"
+#include "kahypar/io/partitioning_output.h"
+#include "kahypar/macros.h"
+#include "kahypar/partition/context.h"
+#include "kahypar/partition/metrics.h"
+
+using namespace kahypar;
+
+static inline double imb(const Hypergraph& hypergraph, const PartitionID k) {
+  HypernodeWeight max_weight = hypergraph.partWeight(0);
+  for (PartitionID i = 1; i != k; ++i) {
+    max_weight = std::max(max_weight, hypergraph.partWeight(i));
+  }
+  return static_cast<double>(max_weight) /
+         ceil(static_cast<double>(hypergraph.totalWeight()) / k) - 1.0;
+}
+
+int main(int argc, char* argv[]) {
+  if (argc != 2 && argc != 3) {
+    std::cout << "No .hgr file specified" << std::endl;
+    std::cout << "Usage: EvaluateMondriaanPartiton <.hgr>  <partition file>" << std::endl;
+    exit(0);
+  }
+  const std::string hgr_filename(argv[1]);
+  Hypergraph hypergraph(io::createHypergraphFromFile(hgr_filename, 2));
+
+
+  PartitionID max_part = 1;
+  std::vector<PartitionID> partition(hypergraph.initialNumNodes(), -1);
+  if (argc == 3) {
+    const std::string partition_filename(argv[2]);
+    std::cout << "Reading partition file: " << partition_filename << std::endl;
+    std::ifstream file(partition_filename);
+    if (file) {
+      HypernodeID vertex = -1;
+      PartitionID part = -1;
+      // header
+      file >> vertex >> max_part;
+      ALWAYS_ASSERT(vertex == hypergraph.initialNumNodes());
+      while (file >> vertex >> part) {
+        // one-based
+        partition[vertex - 1] = part - 1;
+      }
+      file.close();
+    } else {
+      std::cerr << "Error: File not found: " << std::endl;
+    }
+    ALWAYS_ASSERT(std::none_of(std::begin(partition), std::end(partition),
+                               [](PartitionID i) {
+      return i == -1;
+    }));
+  }
+
+  if (partition.size() != 0 && partition.size() != hypergraph.initialNumNodes()) {
+    std::cout << "partition file has incorrect size. Exiting." << std::endl;
+    exit(-1);
+  }
+
+  LOG << V(max_part);
+  hypergraph.changeK(max_part);
+
+  for (size_t index = 0; index < partition.size(); ++index) {
+    hypergraph.setNodePart(index, partition[index]);
+  }
+
+  Context context;
+  context.partition.k = max_part;
+
+  for (PartitionID i = 0; i < context.partition.k; ++i) {
+    LOG << i << V(hypergraph.partSize(i)) << V(hypergraph.partWeight(i));
+  }
+
+  std::cout << "***********************" << hypergraph.k()
+            << "-way Partition Result************************" << std::endl;
+  std::cout << "cut=" << metrics::hyperedgeCut(hypergraph) << std::endl;
+  std::cout << "soed=" << metrics::soed(hypergraph) << std::endl;
+  std::cout << "km1= " << metrics::km1(hypergraph) << std::endl;
+  std::cout << "absorption= " << metrics::absorption(hypergraph) << std::endl;
+  std::cout << "imbalance= " << imb(hypergraph, context.partition.k)
+            << std::endl;
+
+  std::cout << "RESULT"
+            << " graph=" << hgr_filename.substr(hgr_filename.find_last_of('/') + 1)
+            << " k=" << context.partition.k
+            << " imbalance=" << imb(hypergraph, context.partition.k)
+            << " cut=" << metrics::hyperedgeCut(hypergraph)
+            << " soed=" << metrics::soed(hypergraph)
+            << " km1=" << metrics::km1(hypergraph) << std::endl;
+
+  return 0;
+}

--- a/tools/hgr_to_mondriaan_mtx_converter.cc
+++ b/tools/hgr_to_mondriaan_mtx_converter.cc
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * This file is part of KaHyPar.
+ *
+ * Copyright (C) 2019 Sebastian Schlag <sebastian.schlag@kit.edu>
+ *
+ * KaHyPar is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KaHyPar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with KaHyPar.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+
+#include <iostream>
+#include <string>
+
+#include "kahypar/definitions.h"
+#include "kahypar/io/hypergraph_io.h"
+#include "kahypar/macros.h"
+#include "tools/hgr_to_mtx_conversion.h"
+
+int main(int argc, char* argv[]) {
+  if (argc != 2) {
+    std::cout << "No hypergraph file specified" << std::endl;
+  }
+  std::string hypergraph_filename(argv[1]);
+  std::string mtx_filename(hypergraph_filename + ".mondriaan.mtx");
+  LOG << "Converting hypergraph " << hypergraph_filename << "to mondriaan mtx format:"
+      << mtx_filename << "...";
+  kahypar::Hypergraph input_hypergraph = kahypar::io::createHypergraphFromFile(hypergraph_filename, 2);
+  kahypar::writeHypergraphInMatrixMarketFormat(input_hypergraph, mtx_filename);
+  LOG << "... done!";
+  return 0;
+}

--- a/tools/hgr_to_mondriaan_mtx_converter.cc
+++ b/tools/hgr_to_mondriaan_mtx_converter.cc
@@ -30,8 +30,8 @@ int main(int argc, char* argv[]) {
   if (argc != 2) {
     std::cout << "No hypergraph file specified" << std::endl;
   }
-  std::string hypergraph_filename(argv[1]);
-  std::string mtx_filename(hypergraph_filename + ".mondriaan.mtx");
+  const std::string hypergraph_filename(argv[1]);
+  const std::string mtx_filename(hypergraph_filename + ".mondriaan.mtx");
   LOG << "Converting hypergraph " << hypergraph_filename << "to mondriaan mtx format:"
       << mtx_filename << "...";
   kahypar::Hypergraph input_hypergraph = kahypar::io::createHypergraphFromFile(hypergraph_filename, 2);

--- a/tools/hgr_to_mtx_conversion.h
+++ b/tools/hgr_to_mtx_conversion.h
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * This file is part of KaHyPar.
+ *
+ * Copyright (C) 2019 Sebastian Schlag <sebastian.schlag@kit.edu>
+ *
+ * KaHyPar is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KaHyPar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with KaHyPar.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ ******************************************************************************/
+
+#pragma once
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "kahypar/definitions.h"
+
+namespace kahypar {
+/// see https://www.staff.science.uu.nl/~bisse101/Mondriaan/Docs/HYPERGRAPH.html
+void writeHypergraphInMatrixMarketFormat(const Hypergraph& hypergraph,
+                                         const std::string& out_filename) {
+  std::ofstream out_stream(out_filename.c_str());
+  out_stream << "%%MatrixMarket weightedmatrix coordinate pattern general" << std::endl;
+  out_stream << hypergraph.initialNumEdges() << " "
+             << hypergraph.initialNumNodes() << " "
+             << hypergraph.initialNumPins() << " "
+             << "2" << std::endl;
+  for (const auto he : hypergraph.edges()) {
+    for (const auto pin : hypergraph.pins(he)) {
+      out_stream << (he + 1) << " " << (pin + 1) << std::endl;
+    }
+  }
+  for (const auto hn : hypergraph.nodes()) {
+    out_stream << hypergraph.nodeWeight(hn) << std::endl;
+  }
+  out_stream.close();
+}
+}  // namespace kahypar

--- a/tools/hgr_to_mtx_conversion_test.cc
+++ b/tools/hgr_to_mtx_conversion_test.cc
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * This file is part of KaHyPar.
+ *
+ * Copyright (C) 2019 Sebastian Schlag <sebastian.schlag@kit.edu>
+ *
+ * KaHyPar is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KaHyPar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with KaHyPar.  If not, see <http://www.gnu.org/licenses/>.
+ *
+******************************************************************************/
+#include "gtest/gtest.h"
+
+#include "kahypar/definitions.h"
+#include "kahypar/io/hypergraph_io.h"
+#include "tools/hgr_to_mtx_conversion.h"
+
+#include <vector>
+
+using ::testing::Test;
+
+namespace kahypar {
+TEST(AHypergraph, CanBeConvertedToMatrixMarketFormatForMondriaanPartitioning) {
+  const std::string input_hypergraph_filename("test_instances/mondriaan_example.hgr");
+  Hypergraph input_hypergraph = kahypar::io::createHypergraphFromFile(input_hypergraph_filename, 2);
+
+  const std::string mtx_filename("test_instances/mondriaan_example.mtx");
+
+  writeHypergraphInMatrixMarketFormat(input_hypergraph, mtx_filename);
+
+  std::ifstream mtx_file(mtx_filename);
+
+  std::vector<int> expected = { 4, 5, 8, 2, 1, 1, 2, 1, 2, 2, 3, 2, 3, 3, 3, 4, 4, 3, 4, 4, 1, 1, 1, 1, 1 };
+  std::reverse(std::begin(expected), std::end(expected));
+
+  std::string line;
+  std::getline(mtx_file, line);
+  // skip any comments
+  while (line[0] == '%') {
+    std::getline(mtx_file, line);
+  }
+
+  for (int i = 0; i < 14; ++i) {
+    std::istringstream line_stream(line);
+    int input = -1;
+    while (line_stream >> input) {
+      if (expected.back() == input) {
+        expected.pop_back();
+      }
+    }
+    std::getline(mtx_file, line);
+  }
+  for (const auto x :  expected) {
+    LOG << x;
+  }
+  ASSERT_TRUE(expected.empty());
+}
+}  // namespace kahypar

--- a/tools/test_instances/mondriaan_example.hgr
+++ b/tools/test_instances/mondriaan_example.hgr
@@ -1,0 +1,6 @@
+% https://www.staff.science.uu.nl/~bisse101/Mondriaan/Docs/HYPERGRAPH.html
+4 5
+1
+1 2
+2 3 4
+3 4


### PR DESCRIPTION
Mondriaan uses the matrix market input format (see https://www.staff.science.uu.nl/~bisse101/Mondriaan/Docs/HYPERGRAPH.html) and a slightly different partition file format.
We therefore provide tools to convert hypergraphs in hMETIS format to matrix market format as well as a tool to evaluate quality and balance of Mondriaans partitions.