### PR TITLE
Add missing static to operator implementations

### DIFF
--- a/kahypar/partition/context_enum_classes.h
+++ b/kahypar/partition/context_enum_classes.h
@@ -178,7 +178,7 @@ enum class FlowExecutionMode : uint8_t {
 };
 
 
-std::ostream& operator<< (std::ostream& os, const EvoReplaceStrategy& replace) {
+static std::ostream& operator<< (std::ostream& os, const EvoReplaceStrategy& replace) {
   switch (replace) {
     case EvoReplaceStrategy::worst: return os << "worst";
     case EvoReplaceStrategy::diverse: return os << "diverse";
@@ -188,7 +188,7 @@ std::ostream& operator<< (std::ostream& os, const EvoReplaceStrategy& replace) {
   return os << static_cast<uint8_t>(replace);
 }
 
-std::ostream& operator<< (std::ostream& os, const EvoCombineStrategy& combine) {
+static std::ostream& operator<< (std::ostream& os, const EvoCombineStrategy& combine) {
   switch (combine) {
     case EvoCombineStrategy::basic: return os << "basic";
     case EvoCombineStrategy::edge_frequency: return os << "edge_frequency";
@@ -198,7 +198,7 @@ std::ostream& operator<< (std::ostream& os, const EvoCombineStrategy& combine) {
   return os << static_cast<uint8_t>(combine);
 }
 
-std::ostream& operator<< (std::ostream& os, const EvoMutateStrategy& mutation) {
+static std::ostream& operator<< (std::ostream& os, const EvoMutateStrategy& mutation) {
   switch (mutation) {
     case EvoMutateStrategy::new_initial_partitioning_vcycle:
       return os << "new_initial_partitioning_vcycle";
@@ -210,7 +210,7 @@ std::ostream& operator<< (std::ostream& os, const EvoMutateStrategy& mutation) {
 }
 
 
-std::ostream& operator<< (std::ostream& os, const EvoDecision& decision) {
+static std::ostream& operator<< (std::ostream& os, const EvoDecision& decision) {
   switch (decision) {
     case EvoDecision::normal:  return os << "normal";
     case EvoDecision::mutation:  return os << "mutation";
@@ -220,7 +220,7 @@ std::ostream& operator<< (std::ostream& os, const EvoDecision& decision) {
   return os << static_cast<uint8_t>(decision);
 }
 
-std::ostream& operator<< (std::ostream& os, const RatingPartitionPolicy& policy) {
+static std::ostream& operator<< (std::ostream& os, const RatingPartitionPolicy& policy) {
   switch (policy) {
     case RatingPartitionPolicy::normal: return os << "normal";
     case RatingPartitionPolicy::evolutionary: return os << "evolutionary";
@@ -229,7 +229,7 @@ std::ostream& operator<< (std::ostream& os, const RatingPartitionPolicy& policy)
   return os << static_cast<uint8_t>(policy);
 }
 
-std::ostream& operator<< (std::ostream& os, const Mode& mode) {
+static std::ostream& operator<< (std::ostream& os, const Mode& mode) {
   switch (mode) {
     case Mode::recursive_bisection: return os << "recursive";
     case Mode::direct_kway: return os << "direct";
@@ -239,7 +239,7 @@ std::ostream& operator<< (std::ostream& os, const Mode& mode) {
   return os << static_cast<uint8_t>(mode);
 }
 
-std::ostream& operator<< (std::ostream& os, const ContextType& type) {
+static std::ostream& operator<< (std::ostream& os, const ContextType& type) {
   if (type == ContextType::main) {
     return os << "main";
   } else {
@@ -248,7 +248,7 @@ std::ostream& operator<< (std::ostream& os, const ContextType& type) {
   return os << static_cast<uint8_t>(type);
 }
 
-std::ostream& operator<< (std::ostream& os, const CommunityPolicy& comm_policy) {
+static std::ostream& operator<< (std::ostream& os, const CommunityPolicy& comm_policy) {
   switch (comm_policy) {
     case CommunityPolicy::use_communities: return os << "true";
     case CommunityPolicy::ignore_communities: return os << "false";
@@ -258,7 +258,7 @@ std::ostream& operator<< (std::ostream& os, const CommunityPolicy& comm_policy) 
   return os << static_cast<uint8_t>(comm_policy);
 }
 
-std::ostream& operator<< (std::ostream& os, const HeavyNodePenaltyPolicy& heavy_hn_policy) {
+static std::ostream& operator<< (std::ostream& os, const HeavyNodePenaltyPolicy& heavy_hn_policy) {
   switch (heavy_hn_policy) {
     case HeavyNodePenaltyPolicy::multiplicative_penalty: return os << "multiplicative";
     case HeavyNodePenaltyPolicy::no_penalty: return os << "no_penalty";
@@ -268,7 +268,7 @@ std::ostream& operator<< (std::ostream& os, const HeavyNodePenaltyPolicy& heavy_
   return os << static_cast<uint8_t>(heavy_hn_policy);
 }
 
-std::ostream& operator<< (std::ostream& os, const AcceptancePolicy& acceptance_policy) {
+static std::ostream& operator<< (std::ostream& os, const AcceptancePolicy& acceptance_policy) {
   switch (acceptance_policy) {
     case AcceptancePolicy::best: return os << "best";
     case AcceptancePolicy::best_prefer_unmatched: return os << "best_prefer_unmatched";
@@ -278,7 +278,7 @@ std::ostream& operator<< (std::ostream& os, const AcceptancePolicy& acceptance_p
   return os << static_cast<uint8_t>(acceptance_policy);
 }
 
-std::ostream& operator<< (std::ostream& os, const FixVertexContractionAcceptancePolicy& acceptance_policy) {
+static std::ostream& operator<< (std::ostream& os, const FixVertexContractionAcceptancePolicy& acceptance_policy) {
   switch (acceptance_policy) {
     case FixVertexContractionAcceptancePolicy::free_vertex_only: return os << "free_vertex_only";
     case FixVertexContractionAcceptancePolicy::fixed_vertex_allowed: return os << "fixed_vertex_allowed";
@@ -289,7 +289,7 @@ std::ostream& operator<< (std::ostream& os, const FixVertexContractionAcceptance
   return os << static_cast<uint8_t>(acceptance_policy);
 }
 
-std::ostream& operator<< (std::ostream& os, const RatingFunction& func) {
+static std::ostream& operator<< (std::ostream& os, const RatingFunction& func) {
   switch (func) {
     case RatingFunction::heavy_edge: return os << "heavy_edge";
     case RatingFunction::edge_frequency: return os << "edge_frequency";
@@ -299,7 +299,7 @@ std::ostream& operator<< (std::ostream& os, const RatingFunction& func) {
   return os << static_cast<uint8_t>(func);
 }
 
-std::ostream& operator<< (std::ostream& os, const Objective& objective) {
+static std::ostream& operator<< (std::ostream& os, const Objective& objective) {
   switch (objective) {
     case Objective::cut: return os << "cut";
     case Objective::km1: return os << "km1";
@@ -309,7 +309,7 @@ std::ostream& operator<< (std::ostream& os, const Objective& objective) {
   return os << static_cast<uint8_t>(objective);
 }
 
-std::ostream& operator<< (std::ostream& os, const InitialPartitioningTechnique& technique) {
+static std::ostream& operator<< (std::ostream& os, const InitialPartitioningTechnique& technique) {
   switch (technique) {
     case InitialPartitioningTechnique::flat: return os << "flat";
     case InitialPartitioningTechnique::multilevel: return os << "multilevel";
@@ -319,7 +319,7 @@ std::ostream& operator<< (std::ostream& os, const InitialPartitioningTechnique& 
   return os << static_cast<uint8_t>(technique);
 }
 
-std::ostream& operator<< (std::ostream& os, const CoarseningAlgorithm& algo) {
+static std::ostream& operator<< (std::ostream& os, const CoarseningAlgorithm& algo) {
   switch (algo) {
     case CoarseningAlgorithm::heavy_full: return os << "heavy_full";
     case CoarseningAlgorithm::heavy_lazy: return os << "heavy_lazy";
@@ -331,7 +331,7 @@ std::ostream& operator<< (std::ostream& os, const CoarseningAlgorithm& algo) {
   return os << static_cast<uint8_t>(algo);
 }
 
-std::ostream& operator<< (std::ostream& os, const RefinementAlgorithm& algo) {
+static std::ostream& operator<< (std::ostream& os, const RefinementAlgorithm& algo) {
   switch (algo) {
     case RefinementAlgorithm::twoway_fm: return os << "twoway_fm";
     case RefinementAlgorithm::kway_fm: return os << "kway_fm";
@@ -348,7 +348,7 @@ std::ostream& operator<< (std::ostream& os, const RefinementAlgorithm& algo) {
   return os << static_cast<uint8_t>(algo);
 }
 
-std::ostream& operator<< (std::ostream& os, const InitialPartitionerAlgorithm& algo) {
+static std::ostream& operator<< (std::ostream& os, const InitialPartitionerAlgorithm& algo) {
   switch (algo) {
     case InitialPartitionerAlgorithm::greedy_sequential: return os << "greedy_sequential";
     case InitialPartitionerAlgorithm::greedy_global: return os << "greedy_global";
@@ -369,7 +369,7 @@ std::ostream& operator<< (std::ostream& os, const InitialPartitionerAlgorithm& a
   return os << static_cast<uint8_t>(algo);
 }
 
-std::ostream& operator<< (std::ostream& os, const LouvainEdgeWeight& weight) {
+static std::ostream& operator<< (std::ostream& os, const LouvainEdgeWeight& weight) {
   switch (weight) {
     case LouvainEdgeWeight::hybrid: return os << "hybrid";
     case LouvainEdgeWeight::uniform: return os << "uniform";
@@ -381,7 +381,7 @@ std::ostream& operator<< (std::ostream& os, const LouvainEdgeWeight& weight) {
   return os << static_cast<uint8_t>(weight);
 }
 
-std::ostream& operator<< (std::ostream& os, const RefinementStoppingRule& rule) {
+static std::ostream& operator<< (std::ostream& os, const RefinementStoppingRule& rule) {
   switch (rule) {
     case RefinementStoppingRule::simple: return os << "simple";
     case RefinementStoppingRule::adaptive_opt: return os << "adaptive_opt";
@@ -391,7 +391,7 @@ std::ostream& operator<< (std::ostream& os, const RefinementStoppingRule& rule) 
   return os << static_cast<uint8_t>(rule);
 }
 
-std::ostream& operator<< (std::ostream& os, const FlowAlgorithm& algo) {
+static std::ostream& operator<< (std::ostream& os, const FlowAlgorithm& algo) {
   switch (algo) {
     case FlowAlgorithm::boykov_kolmogorov: return os << "boykov_kolmogorov";
     case FlowAlgorithm::ibfs: return os << "ibfs";
@@ -401,7 +401,7 @@ std::ostream& operator<< (std::ostream& os, const FlowAlgorithm& algo) {
   return os << static_cast<uint8_t>(algo);
 }
 
-std::ostream& operator<< (std::ostream& os, const FlowNetworkType& type) {
+static std::ostream& operator<< (std::ostream& os, const FlowNetworkType& type) {
   switch (type) {
     case FlowNetworkType::hybrid: return os << "hybrid";
     case FlowNetworkType::UNDEFINED: return os << "UNDEFINED";
@@ -410,7 +410,7 @@ std::ostream& operator<< (std::ostream& os, const FlowNetworkType& type) {
   return os << static_cast<uint8_t>(type);
 }
 
-std::ostream& operator<< (std::ostream& os, const FlowExecutionMode& mode) {
+static std::ostream& operator<< (std::ostream& os, const FlowExecutionMode& mode) {
   switch (mode) {
     case FlowExecutionMode::constant: return os << "constant";
     case FlowExecutionMode::multilevel: return os << "multilevel";


### PR DESCRIPTION
Hallo Sebastian,

ich bin der Student, der gerade bei Tobias seine BA schreibt.

Beim Einbinden der header-only Library `kahypar` bin ich auf ein kleines Problem gestoßen. Inkludiert man beim Linken die header-only Library, um eure Datenstrukturen wiederzuverwenden, so schlägt dies mit der Meldung 

> multiple definition of ... first defined here ...

 fehl. Das Problem lässt sich allerdings lösen, indem die entsprechenden Operator-Implementierungen mit `static` annotiert werden. Für Rückfragen stehe ich gerne zur Verfügung.

Mit freundlichen Grüßen,
Tobias Fuchs
